### PR TITLE
Spawn config feature

### DIFF
--- a/KeyCardPermissions/Extensions/PlayerExtensions.cs
+++ b/KeyCardPermissions/Extensions/PlayerExtensions.cs
@@ -1,0 +1,58 @@
+﻿using Exiled.API.Features;
+using Exiled.API.Features.Items;
+using System;
+using System.Collections.Generic;
+namespace KeyCardPermissions.Extensions
+{
+    /// <summary>
+    /// A set of extensions used in this plugin.
+    /// </summary>
+    public static class PlayerExtensions
+    {
+        /// <summary>
+        /// Checks whether the player has a keycard of a specific permission.
+        /// </summary>
+        /// <param name="player"><see cref="Player"/> trying to interact.</param>
+        /// <param name="permissions">The permission that's gonna be searched for.</param>
+        /// <param name="requiresAllPermissions">Whether all permissions are required.</param>
+        /// <returns>Whether the player has the required keycard.</returns>
+        public static bool ModifyKeycardPermissions(this Player player, Config curr_config, bool requiresAllPermissions = false)
+        {
+            Dictionary<string, string> config_keys = KeyCardPermissions.early_config.CardPermissions;
+            if (config_keys == null || config_keys.Count == 0)
+            {
+                return false;
+            }
+
+
+            Log.Info($"We are definitely modifying the card right..");
+            foreach (Item player_item in player.Items)
+            {
+                if (player_item is Keycard keycard)
+                {
+                    string card_name = ((Keycard)player_item).Type.ToString();
+                    Log.Info($"What is the card name {card_name}");
+                    if (config_keys.ContainsKey(card_name))
+                    {
+                        config_keys.TryGetValue(card_name, out string all_permissions);
+                        string[] config_perm_arr = all_permissions.Split(',');
+                        ushort[] parsed_int_permissions = Array.ConvertAll(config_perm_arr, ushort.Parse);
+                        ushort new_permission = 0;
+
+                        for (int pos = 0; pos < parsed_int_permissions.Length; pos++)
+                        {
+                            new_permission |= parsed_int_permissions[pos];
+                        }
+
+                        ((Keycard)player_item).Base.Permissions = ((Interactables.Interobjects.DoorUtils.KeycardPermissions)(new_permission));
+                        Log.Info($"Current keycard permissions { ((Keycard)player_item).Base.Permissions}");
+                    }
+
+                }
+
+            }
+
+            return true;
+        }
+    }
+}

--- a/KeyCardPermissions/Handlers/EventsHandler.cs
+++ b/KeyCardPermissions/Handlers/EventsHandler.cs
@@ -1,0 +1,50 @@
+﻿using Exiled.Events.EventArgs;
+using KeyCardPermissions.Extensions;
+using Players = Exiled.Events.Handlers.Player;
+namespace KeyCardPermissions.Handlers
+{
+    public class EventsHandler
+    {
+        private readonly Config config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventsHandler"/> class.
+        /// </summary>
+        /// <param name="config">The <see cref="Config"/> settings that will be used.</param>
+        public EventsHandler(Config config) => this.config = config;
+
+        /// <summary>
+        /// Registers all events used.
+        /// </summary>
+        internal void Start()
+        {
+            this.config.ProgramLevel.TryGetValue("Spawn_Config", out bool is_enabled);
+            if (!is_enabled)
+            {
+                return;
+            }
+            Players.Spawning += OnRespawn;
+        }
+
+        /// <summary>
+        /// Unregisters all events used.
+        /// </summary>
+        public void Stop()
+        {
+            this.config.ProgramLevel.TryGetValue("Spawn_Config", out bool is_enabled);
+            if (!is_enabled)
+            {
+                return;
+            }
+            Players.Spawning -= OnRespawn;
+        }
+        private void OnRespawn(SpawningEventArgs ev)
+        {
+            ev.Player.ModifyKeycardPermissions(this.config);
+        }
+
+
+
+
+    }
+}

--- a/KeyCardPermissions/Handlers/EventsHandler.cs
+++ b/KeyCardPermissions/Handlers/EventsHandler.cs
@@ -24,6 +24,7 @@ namespace KeyCardPermissions.Handlers
                 return;
             }
             Players.Spawning += OnRespawn;
+            Players.PickingUpItem += OnPickup;
         }
 
         /// <summary>
@@ -37,7 +38,14 @@ namespace KeyCardPermissions.Handlers
                 return;
             }
             Players.Spawning -= OnRespawn;
+            Players.PickingUpItem -= OnPickup;
         }
+
+        private void OnPickup(PickingUpItemEventArgs ev)
+        {
+            ev.Player.ModifyKeycardPermissions(this.config);
+        }
+
         private void OnRespawn(SpawningEventArgs ev)
         {
             ev.Player.ModifyKeycardPermissions(this.config);

--- a/KeyCardPermissions/KeyCardPermissions.cs
+++ b/KeyCardPermissions/KeyCardPermissions.cs
@@ -1,6 +1,7 @@
 ﻿using Exiled.API.Enums;
 using Exiled.API.Features;
 using HarmonyLib;
+using KeyCardPermissions.Handlers;
 
 namespace KeyCardPermissions
 {
@@ -40,6 +41,9 @@ namespace KeyCardPermissions
         }
 
 
+        /// <inheritdoc cref="EventsHandler"/>
+        public EventsHandler Handler { get; private set; }
+
         /// <summary>
         /// Registers events for EXILE to hook unto with cororotines (I think?)
         /// </summary>
@@ -52,6 +56,9 @@ namespace KeyCardPermissions
                 return;
             }
             early_config = Config;
+
+            Handler = new EventsHandler(Config);
+            Handler.Start();
 
             //currentSpectator = new Handlers.SpectatorMonitor();
 

--- a/KeyCardPermissions/KeyCardPermissions.csproj
+++ b/KeyCardPermissions/KeyCardPermissions.csproj
@@ -126,6 +126,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config.cs" />
+    <Compile Include="Extensions\PlayerExtensions.cs" />
+    <Compile Include="Handlers\EventsHandler.cs" />
     <Compile Include="Patches\OverrideDefaultItems.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="KeyCardPermissions.cs" />

--- a/KeyCardPermissions/Patches/OverrideDefaultItems.cs
+++ b/KeyCardPermissions/Patches/OverrideDefaultItems.cs
@@ -45,22 +45,19 @@ namespace KeyCardPermissions.Patches
                     return;
                 }
 
-                List<string> keyList = new List<string>(config_keys.Keys);
+
                 List<KeyValuePair<global::ItemType, InventorySystem.Items.ItemBase>> items_to_replace = new List<KeyValuePair<global::ItemType, InventorySystem.Items.ItemBase>>();
                 foreach (KeyValuePair<global::ItemType, InventorySystem.Items.ItemBase> entry in curr_loaded_items)
                 {
                     string card_name = entry.Key.ToString();
                     if (config_keys.ContainsKey(card_name))
                     {
-                        List<int> permissions_to_add = new List<int>();
-
-
                         config_keys.TryGetValue(card_name, out string all_permissions);
                         string[] config_perm_arr = all_permissions.Split(',');
-                        int[] parsed_int_permissions = Array.ConvertAll(config_perm_arr, int.Parse);
+                        ushort[] parsed_int_permissions = Array.ConvertAll(config_perm_arr, ushort.Parse);
                         Interactables.Interobjects.DoorUtils.KeycardPermissions item = ((KeycardItem)entry.Value).Permissions;
 
-                        int new_permission = 0;
+                        ushort new_permission = 0;
 
                         for (int pos = 0; pos < parsed_int_permissions.Length; pos++)
                         {

--- a/KeyCardPermissions/Properties/AssemblyInfo.cs
+++ b/KeyCardPermissions/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("KeyCardPermissions")]
-[assembly: AssemblyCopyright("Copyright ©  Undid-Iridium 2021")]
+[assembly: AssemblyCopyright("Copyright ©  Undid-Iridium 2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.1")]
+[assembly: AssemblyFileVersion("1.0.0.1")]


### PR DESCRIPTION
Allows the ability to change permissions on the fly when a player is spawned, and when an item is picked up. Normally no other scenario should occur for an item to get into a players inventory as far as I know. I could edge-case it but it is already less performant than a harmony patch but an option if desired. 